### PR TITLE
Add tex-icon to biblatex (.bib) files

### DIFF
--- a/common/icons.json
+++ b/common/icons.json
@@ -1416,7 +1416,7 @@
     "syntaxes": [
       {
         "name": "LaTeX",
-        "scope": "text.tex, text.bibtex, text.log.latex"
+        "scope": "text.tex, text.biblatex, text.bibtex, text.log.latex"
       }
     ]
   },

--- a/preferences/file_type_tex.tmPreferences
+++ b/preferences/file_type_tex.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
   <dict>
     <key>scope</key>
-    <string>text.tex, text.bibtex, text.log.latex</string>
+    <string>text.tex, text.biblatex, text.bibtex, text.log.latex</string>
     <key>settings</key>
     <dict>
       <key>icon</key>


### PR DESCRIPTION
#### Description
This adds the text.biblatex key to the tex-icon file preferences. The tex-icon should also appear for .bib-files

#### Motivation and Context
Since the scope tex.bibtex is in the preferences file it already seems to try to match .bib-files (The scope may have changed on a recent syntax rewrite?).

#### How Has This Been Tested?
I have edited the file locally and the icon appeared for .bib files

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.

PS: I am not sure whether there should be more changes, but it seems to be sufficient.